### PR TITLE
Add IP block management page

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -31,6 +31,7 @@
             this.initDynamicToggles();
             this.initCountrySelect();
             this.initBulkActions();
+            this.initBlockedIps();
         },
 
         /**
@@ -343,6 +344,27 @@
             $('#cb-select-all-1').prop({
                 'checked': checkedCheckboxes === totalCheckboxes,
                 'indeterminate': checkedCheckboxes > 0 && checkedCheckboxes < totalCheckboxes
+            });
+        },
+
+        /**
+         * Initialize actions for blocked IPs management page
+         */
+        initBlockedIps() {
+            $('.unblock-ip').on('click', function () {
+                const ip = $(this).data('ip');
+                if (!confirm('Unblock ' + ip + '?')) return;
+                $.post(ajaxurl, {
+                    action: 'cf7_honeypot_unblock_ip',
+                    ip: ip,
+                    nonce: cf7HoneypotAdmin.unblockNonce
+                }, function (response) {
+                    if (response.success) {
+                        $("tr[data-ip='" + ip + "']").fadeOut(300, function () { $(this).remove(); });
+                    } else {
+                        alert('Error');
+                    }
+                });
             });
         },
 

--- a/cf7-advanced-honeypot.php
+++ b/cf7-advanced-honeypot.php
@@ -391,6 +391,32 @@ class CF7_Advanced_Honeypot
      */
     public function validate_honeypot($result, $tags)
     {
+        // Get form ID and settings
+        $form_id  = isset($_POST['_wpcf7']) ? (int) $_POST['_wpcf7'] : 0;
+        $settings = CF7_Honeypot_Settings::get_instance()->get_form_settings($form_id);
+
+        // Block immediately if IP is blacklisted
+        if (!empty($settings['enabled']) && $this->is_ip_blocked($this->get_client_ip())) {
+            $error_message = $settings['custom_error_message'] ?? __('Unable to send message.', 'cf7-honeypot');
+            $result->invalidate('spam', $error_message);
+
+            $submission = WPCF7_Submission::get_instance();
+            if ($submission) {
+                $submission->set_status('spam');
+                if (method_exists($submission, 'set_response')) {
+                    $submission->set_response($error_message);
+                }
+            }
+
+            add_filter('wpcf7_skip_mail', '__return_true');
+            add_filter('cfdb7_before_save_data', '__return_false');
+            remove_all_actions('wpcf7_before_send_mail');
+            remove_all_actions('wpcf7_mail_sent');
+            remove_all_actions('wpcf7_mail_failed');
+
+            return $result;
+        }
+
         // Get cached field IDs
         $field_ids = $this->get_cached_field_ids();
 
@@ -509,6 +535,35 @@ class CF7_Advanced_Honeypot
         $blocked_ips = get_option('cf7_honeypot_blocked_ips', array());
         $blocked_ips[$ip] = time();
         update_option('cf7_honeypot_blocked_ips', $blocked_ips);
+    }
+
+    /**
+     * Checks if an IP is currently blocked and handles expiration.
+     *
+     * @param string $ip IP address to check
+     * @return bool True if blocked, false otherwise
+     */
+    private function is_ip_blocked($ip)
+    {
+        $blocked_ips = get_option('cf7_honeypot_blocked_ips', array());
+
+        if (!isset($blocked_ips[$ip])) {
+            return false;
+        }
+
+        $settings = get_option('cf7_honeypot_settings');
+        $duration = isset($settings['block_duration']) ? (int) $settings['block_duration'] : 24;
+        $expires  = $blocked_ips[$ip] + ($duration * HOUR_IN_SECONDS);
+
+        if (time() < $expires) {
+            return true;
+        }
+
+        // Remove expired IP
+        unset($blocked_ips[$ip]);
+        update_option('cf7_honeypot_blocked_ips', $blocked_ips);
+
+        return false;
     }
 
     /**
@@ -898,6 +953,7 @@ class CF7_Advanced_Honeypot
     {
         add_action('wp_ajax_cf7_honeypot_delete_records', array($this, 'ajax_delete_records'));
         add_action('wp_ajax_nopriv_cf7_honeypot_delete_records', array($this, 'ajax_delete_records'));
+        add_action('wp_ajax_cf7_honeypot_unblock_ip', array($this, 'ajax_unblock_ip'));
     }
 
     public function ajax_delete_records()
@@ -940,6 +996,34 @@ class CF7_Advanced_Honeypot
                 number_format_i18n($deleted)
             )
         ));
+    }
+
+    /**
+     * AJAX handler to manually unblock an IP address.
+     */
+    public function ajax_unblock_ip()
+    {
+        check_ajax_referer('cf7_honeypot_unblock_ip', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Unauthorized');
+        }
+
+        $ip = isset($_POST['ip']) ? sanitize_text_field($_POST['ip']) : '';
+
+        if (empty($ip)) {
+            wp_send_json_error('Invalid IP');
+        }
+
+        $blocked_ips = get_option('cf7_honeypot_blocked_ips', array());
+
+        if (isset($blocked_ips[$ip])) {
+            unset($blocked_ips[$ip]);
+            update_option('cf7_honeypot_blocked_ips', $blocked_ips);
+            wp_send_json_success(array('message' => __('IP removed', 'cf7-honeypot')));
+        }
+
+        wp_send_json_error('IP not found');
     }
 
     /**

--- a/includes/class-cf7-honeypot-settings.php
+++ b/includes/class-cf7-honeypot-settings.php
@@ -21,8 +21,14 @@ class CF7_Honeypot_Settings
 
     public function add_settings_page()
     {
-        // Non è più necessario aggiungere il submenu qui
-        // poiché viene gestito nella classe principale
+        add_submenu_page(
+            'cf7-honeypot-stats',
+            __('Blocked IPs', 'cf7-honeypot'),
+            __('Blocked IPs', 'cf7-honeypot'),
+            'manage_options',
+            'cf7-honeypot-blocked-ips',
+            array($this, 'render_blocked_ips_page')
+        );
     }
 
     public function register_settings()
@@ -248,6 +254,15 @@ class CF7_Honeypot_Settings
         <?php
     }
 
+    public function render_blocked_ips_page()
+    {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        include plugin_dir_path(dirname(__FILE__)) . 'templates/blocked-ips.php';
+    }
+
     // Render Methods for Different Field Types
     public function render_checkbox_field($args)
     {
@@ -379,7 +394,7 @@ class CF7_Honeypot_Settings
 
     public function enqueue_admin_scripts($hook)
     {
-        if ('cf7-honeypot_page_cf7-honeypot-settings' !== $hook) {
+        if (!in_array($hook, array('cf7-honeypot_page_cf7-honeypot-settings', 'cf7-honeypot_page_cf7-honeypot-blocked-ips'))) {
             return;
         }
 
@@ -485,6 +500,7 @@ class CF7_Honeypot_Settings
     {
         return in_array($hook, array(
             'cf7-honeypot_page_cf7-honeypot-settings',
+            'cf7-honeypot_page_cf7-honeypot-blocked-ips',
             'toplevel_page_cf7-honeypot-stats'
         ));
     }

--- a/templates/blocked-ips.php
+++ b/templates/blocked-ips.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$blocked_ips = get_option('cf7_honeypot_blocked_ips', array());
+$settings    = get_option('cf7_honeypot_settings');
+$duration    = isset($settings['block_duration']) ? (int) $settings['block_duration'] : 24;
+?>
+<div class="cf7-honeypot-wrapper">
+    <h1><?php esc_html_e('Blocked IP Addresses', 'cf7-honeypot'); ?></h1>
+    <?php if (empty($blocked_ips)) : ?>
+        <p><?php esc_html_e('No blocked IPs.', 'cf7-honeypot'); ?></p>
+    <?php else : ?>
+        <table class="wp-list-table widefat fixed striped">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('IP Address', 'cf7-honeypot'); ?></th>
+                    <th><?php esc_html_e('Unblock Date', 'cf7-honeypot'); ?></th>
+                    <th><?php esc_html_e('Actions', 'cf7-honeypot'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($blocked_ips as $ip => $time) :
+                    $unblock = $time + ($duration * HOUR_IN_SECONDS); ?>
+                    <tr data-ip="<?php echo esc_attr($ip); ?>">
+                        <td><?php echo esc_html($ip); ?></td>
+                        <td><?php echo esc_html(date_i18n('d/m/Y H:i', $unblock)); ?></td>
+                        <td><button type="button" class="button unblock-ip" data-ip="<?php echo esc_attr($ip); ?>"><?php esc_html_e('Remove', 'cf7-honeypot'); ?></button></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+    <?php
+    wp_localize_script('cf7-honeypot-admin', 'cf7HoneypotAdmin', array(
+        'unblockNonce' => wp_create_nonce('cf7_honeypot_unblock_ip')
+    ));
+    ?>
+</div>


### PR DESCRIPTION
## Summary
- handle persistent IP blocks with `is_ip_blocked`
- prevent form submission for blocked IPs
- AJAX handler and JS actions for IP removal
- admin page listing blocked IPs
- menu entry for Blocked IPs page

## Testing
- `php -l cf7-advanced-honeypot.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6cc5800832ea3295ab25309e58a