### PR TITLE
Add CSV export handler

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -31,6 +31,7 @@
             this.initDynamicToggles();
             this.initCountrySelect();
             this.initBulkActions();
+            this.initCSVExport();
         },
 
         /**
@@ -343,6 +344,12 @@
             $('#cb-select-all-1').prop({
                 'checked': checkedCheckboxes === totalCheckboxes,
                 'indeterminate': checkedCheckboxes > 0 && checkedCheckboxes < totalCheckboxes
+            });
+        },
+
+        initCSVExport() {
+            $('#export-csv').on('click', () => {
+                window.location = ajaxurl + '?action=cf7_honeypot_export_csv&nonce=' + cf7HoneypotAdmin.exportNonce;
             });
         },
 

--- a/templates/stats-page.php
+++ b/templates/stats-page.php
@@ -122,6 +122,9 @@ $recent_attempts = $wpdb->get_results($wpdb->prepare("
                         <?php esc_html_e('Clear All Logs', 'cf7-honeypot'); ?>
                     </button>
                 </form>
+                <button type="button" id="export-csv" class="cleanup-button">
+                    <?php esc_html_e('Export CSV', 'cf7-honeypot'); ?>
+                </button>
             </div>
         </div>
 
@@ -253,7 +256,8 @@ $recent_attempts = $wpdb->get_results($wpdb->prepare("
         </div>
         <?php
         wp_localize_script('cf7-honeypot-admin', 'cf7HoneypotAdmin', array(
-            'deleteNonce' => wp_create_nonce('cf7_honeypot_delete_records')
+            'deleteNonce' => wp_create_nonce('cf7_honeypot_delete_records'),
+            'exportNonce' => wp_create_nonce('cf7_honeypot_export_csv')
         ));
         ?>
     </div>


### PR DESCRIPTION
## Summary
- add export CSV button
- support CSV AJAX handler
- allow CSV export via JS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6e224d8832e802c26ecc7179f5c